### PR TITLE
Add Docker publish workflow and Jib plugin in Gradle

### DIFF
--- a/.github/workflows/docker-publish-dispatcher.yml
+++ b/.github/workflows/docker-publish-dispatcher.yml
@@ -1,0 +1,20 @@
+name: Docker publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      architecture:
+        description: 'architecture'
+        required: true
+        type: choice
+        options:
+          - arm64
+          - amd64
+          - x86_64
+
+jobs:
+  publish:
+    uses: ./.github/workflows/docker-publish-workflow.yml
+    with:
+      architecture: ${{ inputs.architecture }}
+    secrets: inherit

--- a/.github/workflows/docker-publish-workflow.yml
+++ b/.github/workflows/docker-publish-workflow.yml
@@ -1,0 +1,51 @@
+name: Docker publish
+
+on:
+  workflow_call:
+    inputs:
+      architecture:
+        required: true
+        type: string
+    secrets:
+      SSH_PRIVATE_KEY:
+        required: true
+      SSH_KNOWN_HOSTS:
+        required: true
+      TO_IMAGE:
+        required: true
+      DOCKER_HUB_USERNAME:
+        required: true
+      DOCKER_HUB_PASSWORD:
+        required: true
+
+env:
+  TO_IMAGE: ${{ secrets.TO_IMAGE }}
+  DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+  DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-known-hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+          submodules: true
+
+      - name: Set up JDK 20
+        uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 20
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Publish
+        run: ./gradlew jib -Parchitecture=${{ inputs.architecture }} -Djib.to.image=${{ env.TO_IMAGE }} -Djib.to.auth.username=${{ env.DOCKER_HUB_USERNAME }} -Djib.to.auth.password=${{ env.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,25 @@
+name: Docker publish
+
+on:
+  workflow_dispatch:
+  release:
+    types: [ published ]
+
+jobs:
+  publish-arm64:
+    uses: ./.github/workflows/docker-publish-workflow.yml
+    with:
+      architecture: arm64
+    secrets: inherit
+
+  publish-amd64:
+    uses: ./.github/workflows/docker-publish-workflow.yml
+    with:
+      architecture: arm64
+    secrets: inherit
+
+  publish-x86_64:
+    uses: ./.github/workflows/docker-publish-workflow.yml
+    with:
+      architecture: x86_64
+    secrets: inherit

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'com.google.protobuf'
+    id 'com.google.cloud.tools.jib' version '3.4.0'
 }
 
 subprojects {
@@ -56,6 +57,31 @@ protobuf {
             task.descriptorSetOptions.path =
                     "${layout.buildDirectory.getAsFile().get().path}/resources/main/META-INF/armeria/grpc/service-name.dsc"
         }
+    }
+}
+
+jib {
+    def targetArchitecture = project.hasProperty('architecture') ? project.property('architecture') : "x86_64";
+
+    from {
+        image = "azul/zulu-openjdk:20-latest"
+
+        platforms {
+            platform {
+                architecture = targetArchitecture
+                os = "linux"
+            }
+        }
+    }
+
+    to {
+        tags = ["${project.version}", "${targetArchitecture}", "latest"]
+    }
+
+    container {
+        mainClass = "boozilla.houston.Application"
+        creationTime = "USE_CURRENT_TIMESTAMP"
+        ports = ["8080"]
     }
 }
 


### PR DESCRIPTION
Introduced the Jib plugin in the build.gradle file to build Docker images. Additionally, new GitHub workflow files have been created to publish Docker images for different architectures. This allows different Docker images to be easily managed and published for different architectures.