### PR TITLE
Update Docker publish workflow names

### DIFF
--- a/.github/workflows/docker-publish-dispatcher.yml
+++ b/.github/workflows/docker-publish-dispatcher.yml
@@ -1,4 +1,4 @@
-name: Docker publish
+name: Docker publish dispatcher
 
 on:
   workflow_dispatch:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,4 @@
-name: Docker publish
+name: Docker publish all
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Docker publish workflow names were updated to more accurately reflect their functionality. The 'docker-publish.yml' now has the name 'Docker publish all', and 'docker-publish-dispatcher.yml' is renamed to 'Docker publish dispatcher'. These changes improve clarity and make workflows easier to manage.