### PR TITLE
Correct target architecture in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ jib {
 
         platforms {
             platform {
-                architecture = "amr64"
+                architecture = "arm64"
                 os = "linux"
             }
 


### PR DESCRIPTION
Fixed a typo in the target architecture value from "amr64" to "arm64". This correction ensures the correct architecture is used in the build script. This change can improve the build process and avoid possible errors during the application deployment.